### PR TITLE
Rename organization

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -49,7 +49,7 @@ get_download_url() {
     tag="v${tag}"
   fi
 
-  echo "https://github.com/windmilleng/tilt/releases/download/${tag}/tilt.${version}.${platform}.${arch}.tar.gz"
+  echo "https://github.com/tilt-dev/tilt/releases/download/${tag}/tilt.${version}.${platform}.${arch}.tar.gz"
 }
 
 install_plugin "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-repo=windmilleng/tilt
+repo=tilt-dev/tilt
 
 cmd="curl --silent --location"
 releases_path="https://api.github.com/repos/$repo/releases"


### PR DESCRIPTION
The tilt project was moved from being under windmilleng to the tilt-dev
on GitHub.